### PR TITLE
feat: add manual Docker build and release workflow

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -1,0 +1,95 @@
+name: Manual Docker Build & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker tag for the image'
+        required: true
+        default: 'latest'
+        type: string
+      git_ref:
+        description: 'Git ref to build (branch/tag/commit)'
+        required: false
+        default: 'main'
+        type: string
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref }}
+      
+      - name: Extract version from mix.exs
+        id: version
+        run: |
+          VERSION=$(grep -oP 'version: "\K[^"]+' mix.exs)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kbve/realtime
+          tags: |
+            type=raw,value=${{ inputs.docker_tag }}
+            type=raw,value=v${{ steps.version.outputs.version }}
+            type=sha,prefix={{branch}}-
+            type=raw,value={{branch}}-{{date 'YYYYMMDD-HHmmss'}}
+          labels: |
+            org.opencontainers.image.title=Supabase Realtime
+            org.opencontainers.image.description=Realtime server for Supabase
+            org.opencontainers.image.vendor=Supabase
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      - name: Output image details
+        run: |
+          echo "## Docker Image Built Successfully! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image Registry:** GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
+          echo "**Primary Tag:** \`ghcr.io/kbve/realtime:${{ inputs.docker_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Version Tag:** \`ghcr.io/kbve/realtime:v${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### All Tags:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull Command:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/kbve/realtime:${{ inputs.docker_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Run Command:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker run -p 4000:4000 ghcr.io/kbve/realtime:${{ inputs.docker_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Add GitHub Action for manual Docker image builds
- Deploy to GitHub Container Registry under KBVE org
- Automatic version extraction from mix.exs
- Single architecture (x86_64) builds with caching
- Multiple tagging: custom tag + version tag + SHA + timestamp
- Manual trigger with customizable Docker tag input